### PR TITLE
Probable fix for the unwanted tag field behaviour

### DIFF
--- a/layouts/joomla/html/tag.php
+++ b/layouts/joomla/html/tag.php
@@ -50,7 +50,7 @@ if ($allowCustom)
 			$('" . $selector . "_chzn input').keyup(function(event) {
 
 				// Tag is greater than the minimum required chars and enter pressed
-				if (this.value && this.value.length >= " . $minTermLength . " && (event.which === 13 || event.which === 188)) {
+				if (this.value && this.value.length >= " . $minTermLength . " && event.which === 13) {
 
 					// Search an highlighted result
 					var highlighted = $('" . $selector . "_chzn').find('li.active-result.highlighted').first();


### PR DESCRIPTION
**Javascript Char Key Code 188** or **comma** is located on the same key as Russian letter **б**. So when I try to enter _тобико_ the script stops and creates _тоб_ tag.

Of course separating tags with commas is a good idea, but it can cause glitches on non-QWERTY keyboards.

Probably there could be more elegant solution...

Thanks

Pull Request for Issue #11835 created by @ciar4n